### PR TITLE
Fix directory permissions in certbot example

### DIFF
--- a/examples/certbot/certbot.go
+++ b/examples/certbot/certbot.go
@@ -91,7 +91,7 @@ func main() {
 	webroot = filepath.Join(webroot, ".well-known", "acme-challenge")
 	if _, err := os.Stat(webroot); os.IsNotExist(err) {
 		log.Printf("Making directory path: %s", webroot)
-		if err := os.MkdirAll(webroot, 0644); err != nil {
+		if err := os.MkdirAll(webroot, 0755); err != nil {
 			log.Fatalf("Error creating webroot path %q: %v", webroot, err)
 		}
 	}


### PR DESCRIPTION
644 does not work for directories in this case. Executable bit
needs to be set for files underneath the directory to be accessed.
Read bit lets the directory structure be read but no more.