### PR TITLE
Create an HTTP client in NewClient instead of using http.DefaultClient

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -25,11 +25,11 @@ const (
 
 // NewClient creates a new acme client given a valid directory url.
 func NewClient(directoryURL string, options ...OptionFunc) (Client, error) {
-	httpClient := http.DefaultClient
-
-	// Set a default http timeout of 60 seconds
-	// can be overridden via OptionFunc eg: acme.NewClient(url, WithHTTPTimeout(10 * time.Second))
-	httpClient.Timeout = 60 * time.Second
+	// Set a default http timeout of 60 seconds, this can be overridden
+	// via an OptionFunc eg: acme.NewClient(url, WithHTTPTimeout(10 * time.Second))
+	httpClient := &http.Client{
+		Timeout: 60 * time.Second,
+	}
 
 	acmeClient := Client{
 		httpClient: httpClient,


### PR DESCRIPTION
There is a [race condition](https://gist.github.com/cpu/0197cad3121dfde656f5fc2f3c5e3362) when creating multiple clients as `NewClient` makes modifications to `http.DefaultClient` without protecting the writes. Instead of adding locking I've just moved to creating a new client (which is functionally the same as `http.DefaultClient`).