### PR TITLE
client: UpdateAccount fixes

### DIFF
--- a/account.go
+++ b/account.go
@@ -39,13 +39,11 @@ func (c Client) NewAccount(privateKey crypto.Signer, onlyReturnExisting, termsOf
 }
 
 // UpdateAccount updates an existing account with the acme service.
-func (c Client) UpdateAccount(account Account, termsOfServiceAgreed bool, contact ...string) (Account, error) {
+func (c Client) UpdateAccount(account Account, contact ...string) (Account, error) {
 	updateAccountReq := struct {
-		TermsOfServiceAgreed bool     `json:"termsOfServiceAgreed"`
-		Contact              []string `json:"contact,omitempty"`
+		Contact []string `json:"contact,omitempty"`
 	}{
-		TermsOfServiceAgreed: termsOfServiceAgreed,
-		Contact:              contact,
+		Contact: contact,
 	}
 
 	_, err := c.post(account.URL, account.URL, account.PrivateKey, updateAccountReq, &account, http.StatusOK)

--- a/account_test.go
+++ b/account_test.go
@@ -87,7 +87,7 @@ func TestClient_NewAccount2(t *testing.T) {
 func TestClient_UpdateAccount(t *testing.T) {
 	account := makeAccount(t)
 	contact := []string{"mailto:test@test.com"}
-	updatedAccount, err := testClient.UpdateAccount(account, true, contact...)
+	updatedAccount, err := testClient.UpdateAccount(account, contact...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestClient_UpdateAccount(t *testing.T) {
 
 func TestClient_UpdateAccount2(t *testing.T) {
 	account := makeAccount(t)
-	updatedAccount, err := testClient.UpdateAccount(Account{PrivateKey: account.PrivateKey, URL: account.URL}, true)
+	updatedAccount, err := testClient.UpdateAccount(Account{PrivateKey: account.PrivateKey, URL: account.URL})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestClient_UpdateAccount2(t *testing.T) {
 		t.Fatalf("account and updated account mismatch, expected: %+v, got: %+v", account, updatedAccount)
 	}
 
-	_, err = testClient.UpdateAccount(Account{PrivateKey: account.PrivateKey}, true)
+	_, err = testClient.UpdateAccount(Account{PrivateKey: account.PrivateKey})
 	if err == nil {
 		t.Fatalf("expected error, got none")
 	}

--- a/examples/certbot/certbot.go
+++ b/examples/certbot/certbot.go
@@ -224,7 +224,7 @@ func loadAccount(client acme.Client) (acme.Account, error) {
 	if err := json.Unmarshal(raw, &aaf); err != nil {
 		return acme.Account{}, fmt.Errorf("error parsing account file %q: %v", accountFile, err)
 	}
-	account, err := client.UpdateAccount(acme.Account{PrivateKey: aaf.PrivateKey, URL: aaf.Url}, true, getContacts()...)
+	account, err := client.UpdateAccount(acme.Account{PrivateKey: aaf.PrivateKey, URL: aaf.Url}, getContacts()...)
 	if err != nil {
 		return acme.Account{}, fmt.Errorf("error updating existing account: %v", err)
 	}


### PR DESCRIPTION
:wave: Hi @eggsampler 

While reviewing https://github.com/eggsampler/acme/pull/10 I noticed that [CI is broken for master](https://travis-ci.com/eggsampler/acme/builds/135920587). Specifically during `make pebble` the `TestClient_UpdateAccount2` integration test is failing:

```
--- FAIL: TestClient_UpdateAccount2 (0.01s)
    account_test.go:104: unexpected error: acme: error code 400 "urn:ietf:params:acme:error:malformed": Use POST-as-GET to retrieve account data instead of doing an empty update
```

I took a look at implementing a fix. I broke it into two parts:

### 5f31272 - remove UpdateAccount termsOfServiceAgreed param.

[RFC 8555 Section 7.1.2 "Account Objects"](https://tools.ietf.org/html/rfc8555#section-7.1.2) describes the "termsOfServiceAgreed" field of the account object as being something that should be included in **newAccount** requests. It isn't updateable by the client.

This commit removes the `termsOfServiceAgreed bool` argument from the `client.UpdateAccount` function since it can't be updated

**Note**: This is a breaking API change. I went with this approach since you're using semver and can account for it there. If you'd rather see the parameter maintained but dropped from the JWS body I'd be happy to implement that instead. WDYT? 

### b0f3824  - use POST-as-GET for no-op UpdateAccount.

When handling `Client.UpdateAccount` requests that won't change the `Account.Contact` treat the intent as fetching up-to-date Account resource information from the server. This should be done with
a POST-as-GET request instead of an empty account update (`{}`).

---

Applying both of these commits fixed `make pebble` in my testing. This in turn seemed to fix the port conflict that was being reported in CI during `make boulder`. I suspect the Pebble cleanup isn't happening properly when unit tests failed but I haven't tried to fix that in this branch.

Thanks for the great project! We've been enjoying using it for integration tests in Boulder.
