### PR TITLE
Add dns-account-01 support from draft-ietf-acme-scoped-dns-challenges

### DIFF
--- a/challenge_test.go
+++ b/challenge_test.go
@@ -32,8 +32,8 @@ func TestClient_UpdateChallenge(t *testing.T) {
 
 	chal := auth.ChallengeMap[ChallengeTypeDNS01]
 
-	preChallenge(auth, chal)
-	defer postChallenge(auth, chal)
+	preChallenge(account, auth, chal)
+	defer postChallenge(account, auth, chal)
 
 	updatedChal, err := testClient.UpdateChallenge(account, chal)
 	if err != nil {

--- a/misc_test.go
+++ b/misc_test.go
@@ -18,3 +18,20 @@ func TestWildcard(t *testing.T) {
 		t.Fatalf("error verifying hostname %s: %v", d, err)
 	}
 }
+
+func TestWildcardDNSAccount(t *testing.T) {
+	d := "*." + randString() + ".com"
+	account, order, _ := makeOrderFinalised(t, []string{ChallengeTypeDNSAccount01}, Identifier{Type: "dns", Value: d})
+
+	certs, err := testClient.FetchCertificates(account, order.Certificate)
+	if err != nil {
+		t.Fatalf("error fetch cert: %v", err)
+	}
+	if len(certs) == 0 {
+		t.Fatal("no certs")
+	}
+
+	if err := certs[0].VerifyHostname(d); err != nil {
+		t.Fatalf("error verifying hostname %s: %v", d, err)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -14,9 +14,10 @@ var ErrUnsupportedKey = errors.New("acme: unknown key type; only RSA and ECDSA a
 // Different possible challenge types provided by an ACME server.
 // See https://tools.ietf.org/html/rfc8555#section-9.7.8
 const (
-	ChallengeTypeDNS01     = "dns-01"
-	ChallengeTypeHTTP01    = "http-01"
-	ChallengeTypeTLSALPN01 = "tls-alpn-01"
+	ChallengeTypeDNS01        = "dns-01"
+	ChallengeTypeDNSAccount01 = "dns-account-01"
+	ChallengeTypeHTTP01       = "http-01"
+	ChallengeTypeTLSALPN01    = "tls-alpn-01"
 
 	// ChallengeTypeTLSSNI01 is deprecated and should not be used.
 	// See: https://community.letsencrypt.org/t/important-what-you-need-to-know-about-tls-sni-validation-issues/50811


### PR DESCRIPTION
This change implements the "dns-account-01" challenge type as specified in:

https://github.com/aaomidi/draft-ietf-acme-scoped-dns-challenges/blob/0058e0800056698fb37f3b2cb31a727c826675fb/draft-ietf-acme-scoped-dns-challenges.mkd#dns-account-01-challenge

The relevant validation label computation is:
```
"_" || base32(SHA-256(<ACCOUNT_RESOURCE_URL>)[0:10]) || "._acme-" || <SCOPE> || "-challenge"
```

Currently SCOPE of `"host"` and `"wildcard"` is implemented, but not SCOPE of `"domain"`.

This implementation is interoperable with the Pebble changes in https://github.com/fastly/pebble/tree/add-dns-account-01 and passes the new `TestWildcardDNSAccount` test.

Solves https://github.com/eggsampler/acme/issues/20.