### PR TITLE
Support draft-ietf-acme-ari-03

### DIFF
--- a/account.go
+++ b/account.go
@@ -20,7 +20,7 @@ func (c Client) NewAccount(privateKey crypto.Signer, onlyReturnExisting, termsOf
 	if termsOfServiceAgreed {
 		opts = append(opts, NewAcctOptAgreeTOS())
 	}
-	if contact != nil && len(contact) > 0 {
+	if len(contact) > 0 {
 		opts = append(opts, NewAcctOptWithContacts(contact...))
 	}
 

--- a/ari.go
+++ b/ari.go
@@ -33,16 +33,6 @@ type RenewalInfo struct {
 // supported by the acme server)
 var ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not")
 
-/*
-func (c Client) HasARISupport(certID string) (*http.Response, error) {
-	if c.dir.RenewalInfo == "" {
-		return nil, ErrRenewalInfoNotSupported
-	}
-
-	return
-}
-
-*/
 // GetRenewalInfo returns the renewal information (if present and supported by
 // the ACME server), and a Retry-After time if indicated in the http response
 // header.

--- a/ari.go
+++ b/ari.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -15,23 +14,6 @@ import (
 	"strings"
 	"time"
 )
-
-// RenewalInfo stores the server-provided suggestions on when to renew
-// certificates.
-type RenewalInfo struct {
-	SuggestedWindow struct {
-		Start time.Time `json:"start"`
-		End   time.Time `json:"end"`
-	} `json:"suggestedWindow"`
-	ExplanationURL string `json:"explanationURL"`
-
-	RetryAfter time.Time `json:"-"`
-}
-
-// ErrRenewalInfoNotSupported is returned by Client.GetRenewalInfo if the
-// renewal info entry isn't present on the acme directory (ie, it's not
-// supported by the acme server)
-var ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not")
 
 // GetRenewalInfo returns the renewal information (if present and supported by
 // the ACME server), and a Retry-After time if indicated in the http response

--- a/ari.go
+++ b/ari.go
@@ -62,7 +62,8 @@ func (c Client) GetRenewalInfo(cert *x509.Certificate) (RenewalInfo, error) {
 	return ri, err
 }
 
-// generateARICertID
+// generateARICertID constructs a certificate identifier as described in
+// draft-ietf-acme-ari-03, section 4.1.
 func generateARICertID(cert *x509.Certificate) (string, error) {
 	if cert == nil {
 		return "", fmt.Errorf("certificate not found")

--- a/ari.go
+++ b/ari.go
@@ -71,7 +71,7 @@ func generateARICertID(cert *x509.Certificate) (string, error) {
 
 	derBytes, err := asn1.Marshal(cert.SerialNumber)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	if len(derBytes) < 3 {

--- a/ari.go
+++ b/ari.go
@@ -41,7 +41,7 @@ func (c Client) GetRenewalInfo(cert *x509.Certificate) (RenewalInfo, error) {
 		return RenewalInfo{}, ErrRenewalInfoNotSupported
 	}
 
-	certID, err := generateARICertID(cert)
+	certID, err := GenerateARICertID(cert)
 	if err != nil {
 		return RenewalInfo{}, fmt.Errorf("acme: error generating certificate id: %v", err)
 	}
@@ -62,9 +62,9 @@ func (c Client) GetRenewalInfo(cert *x509.Certificate) (RenewalInfo, error) {
 	return ri, err
 }
 
-// generateARICertID constructs a certificate identifier as described in
+// GenerateARICertID constructs a certificate identifier as described in
 // draft-ietf-acme-ari-03, section 4.1.
-func generateARICertID(cert *x509.Certificate) (string, error) {
+func GenerateARICertID(cert *x509.Certificate) (string, error) {
 	if cert == nil {
 		return "", fmt.Errorf("certificate not found")
 	}

--- a/ari_test.go
+++ b/ari_test.go
@@ -72,13 +72,13 @@ yNQwCgYIKoZIzj0EAwIDRwAwRAIge09+S5TZAlw5tgtiVvuERV6cT4mfutXIlwTb
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateARICertID(tt.args.cert)
+			got, err := GenerateARICertID(tt.args.cert)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("generateARICertID() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GenerateARICertID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("generateARICertID() error\n got  = %v\n want = %v", got, tt.want)
+				t.Errorf("GenerateARICertID() error\n got  = %v\n want = %v", got, tt.want)
 			}
 		})
 	}

--- a/ari_test.go
+++ b/ari_test.go
@@ -42,30 +42,6 @@ func TestClient_GetRenewalInfo(t *testing.T) {
 	}
 }
 
-func TestClient_UpdateRenewalInfo(t *testing.T) {
-	if testClientMeta.Software == clientPebble {
-		t.Skip("pebble doesnt support ari")
-		return
-	}
-
-	account, order, _ := makeOrderFinalised(t, nil)
-	if order.Certificate == "" {
-		t.Fatalf("no certificate: %+v", order)
-	}
-	certs, err := testClient.FetchCertificates(account, order.Certificate)
-	if err != nil {
-		t.Fatalf("expeceted no error, got: %v", err)
-	}
-	if len(certs) < 2 {
-		t.Fatalf("no certs")
-	}
-	if err := testClient.UpdateRenewalInfo(account, certs[0], true); err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	// TODO: update this test once there's any feedback or change in the renewal info provided by boulder?
-	// as of 2023-04-09, it appears to be the same before updating, and after updating
-}
-
 func Test_generateCertID(t *testing.T) {
 	type args struct {
 		cert *x509.Certificate

--- a/ari_test.go
+++ b/ari_test.go
@@ -1,7 +1,6 @@
 package acme
 
 import (
-	"crypto"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
@@ -25,7 +24,7 @@ func TestClient_GetRenewalInfo(t *testing.T) {
 	if len(certs) < 2 {
 		t.Fatalf("no certs")
 	}
-	renewalInfo, err := testClient.GetRenewalInfo(certs[0], certs[1], crypto.SHA256)
+	renewalInfo, err := testClient.GetRenewalInfo(certs[0])
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -60,7 +59,7 @@ func TestClient_UpdateRenewalInfo(t *testing.T) {
 	if len(certs) < 2 {
 		t.Fatalf("no certs")
 	}
-	if err := testClient.UpdateRenewalInfo(account, certs[0], certs[1], crypto.SHA256, true); err != nil {
+	if err := testClient.UpdateRenewalInfo(account, certs[0], true); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 	// TODO: update this test once there's any feedback or change in the renewal info provided by boulder?
@@ -69,9 +68,7 @@ func TestClient_UpdateRenewalInfo(t *testing.T) {
 
 func Test_generateCertID(t *testing.T) {
 	type args struct {
-		cert     *x509.Certificate
-		issuer   *x509.Certificate
-		hashFunc crypto.Hash
+		cert *x509.Certificate
 	}
 	tests := []struct {
 		name    string
@@ -82,63 +79,30 @@ func Test_generateCertID(t *testing.T) {
 		{
 			name: "ari example",
 			args: args{
-				// certificate taken from draft-ietf-acme-ari-01 appendix A.1. Example End-Entity Certificate
+				// certificate taken from draft-ietf-acme-ari-03 appendix A.1. Example Certificate
 				cert: pem2cert(t, `-----BEGIN CERTIFICATE-----
-MIIDMDCCAhigAwIBAgIIPqNFaGVEHxwwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MB4XDTIyMDMxNzE3NTEwOVoXDTI0MDQx
-NjE3NTEwOVowFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB
-AQUAA4IBDwAwggEKAoIBAQCgm9K/c+il2Pf0f8qhgxn9SKqXq88cOm9ov9AVRbPA
-OWAAewqX2yUAwI4LZBGEgzGzTATkiXfoJ3cN3k39cH6tBbb3iSPuEn7OZpIk9D+e
-3Q9/hX+N/jlWkaTB/FNA+7aE5IVWhmdczYilXa10V9r+RcvACJt0gsipBZVJ4jfJ
-HnWJJGRZzzxqG/xkQmpXxZO7nOPFc8SxYKWdfcgp+rjR2ogYhSz7BfKoVakGPbpX
-vZOuT9z4kkHra/WjwlkQhtHoTXdAxH3qC2UjMzO57Tx+otj0CxAv9O7CTJXISywB
-vEVcmTSZkHS3eZtvvIwPx7I30ITRkYk/tLl1MbyB3SiZAgMBAAGjeDB2MA4GA1Ud
-DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
-AQH/BAIwADAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTAWBgNVHREE
-DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAx0aYvmCk7JYGNEXe
-+hrOfKawkHYzWvA92cI/Oi6h+oSdHZ2UKzwFNf37cVKZ37FCrrv5pFP/xhhHvrNV
-EnOx4IaF7OrnaTu5miZiUWuvRQP7ZGmGNFYbLTEF6/dj+WqyYdVaWzxRqHFu1ptC
-TXysJCeyiGnR+KOOjOOQ9ZlO5JUK3OE4hagPLfaIpDDy6RXQt3ss0iNLuB1+IOtp
-1URpvffLZQ8xPsEgOZyPWOcabTwJrtqBwily+lwPFn2mChUx846LwQfxtsXU/lJg
-HX2RteNJx7YYNeX3Uf960mgo5an6vE8QNAsIoNHYrGyEmXDhTRe9mCHyiW2S7fZq
-o9q12g==
+MIIBQzCB66ADAgECAgUAh2VDITAKBggqhkjOPQQDAjAVMRMwEQYDVQQDEwpFeGFt
+cGxlIENBMCIYDzAwMDEwMTAxMDAwMDAwWhgPMDAwMTAxMDEwMDAwMDBaMBYxFDAS
+BgNVBAMTC2V4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeBZu
+7cbpAYNXZLbbh8rNIzuOoqOOtmxA1v7cRm//AwyMwWxyHz4zfwmBhcSrf47NUAFf
+qzLQ2PPQxdTXREYEnKMjMCEwHwYDVR0jBBgwFoAUaYhba4dGQEHhs3uEe6CuLN4B
+yNQwCgYIKoZIzj0EAwIDRwAwRAIge09+S5TZAlw5tgtiVvuERV6cT4mfutXIlwTb
++FYN/8oCIClDsqBklhB9KAelFiYt9+6FDj3z4KGVelYM5MdsO3pK
 -----END CERTIFICATE-----`),
-				// certificate taken from draft-ietf-acme-ari-01 appendix A.2. Example CA Certificate
-				issuer: pem2cert(t, `-----BEGIN CERTIFICATE-----
-MIIDSzCCAjOgAwIBAgIIOhNWtJ7Igr0wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
-AxMVbWluaWNhIHJvb3QgY2EgM2ExMzU2MCAXDTIyMDMxNzE3NTEwOVoYDzIxMjIw
-MzE3MTc1MTA5WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAzYTEzNTYwggEi
-MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDc3P6cxcCZ7FQOQrYuigReSa8T
-IOPNKmlmX9OrTkPwjThiMNEETYKO1ea99yXPK36LUHC6OLmZ9jVQW2Ny1qwQCOy6
-TrquhnwKgtkBMDAZBLySSEXYdKL3r0jA4sflW130/OLwhstU/yv0J8+pj7eSVOR3
-zJBnYd1AqnXHRSwQm299KXgqema7uwsa8cgjrXsBzAhrwrvYlVhpWFSv3lQRDFQg
-c5Z/ZDV9i26qiaJsCCmdisJZWN7N2luUgxdRqzZ4Cr2Xoilg3T+hkb2y/d6ttsPA
-kaSA+pq3q6Qa7/qfGdT5WuUkcHpvKNRWqnwT9rCYlmG00r3hGgc42D/z1VvfAgMB
-AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
-BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQ4zzDRUaXHVKql
-STWkULGU4zGZpTAfBgNVHSMEGDAWgBQ4zzDRUaXHVKqlSTWkULGU4zGZpTANBgkq
-hkiG9w0BAQsFAAOCAQEArbDHhEjGedjb/YjU80aFTPWOMRjgyfQaPPgyxwX6Dsid
-1i2H1x4ud4ntz3sTZZxdQIrOqtlIWTWVCjpStwGxaC+38SdreiTTwy/nikXGa/6W
-ZyQRppR3agh/pl5LHVO6GsJz3YHa7wQhEhj3xsRwa9VrRXgHbLGbPOFVRTHPjaPg
-Gtsv2PN3f67DsPHF47ASqyOIRpLZPQmZIw6D3isJwfl+8CzvlB1veO0Q3uh08IJc
-fspYQXvFBzYa64uKxNAJMi4Pby8cf4r36Wnb7cL4ho3fOHgAltxdW8jgibRzqZpQ
-   QKyxn2jX7kxeUDt0hFDJE8lOrhP73m66eBNzxe//FQ==
------END CERTIFICATE-----`),
-				hashFunc: crypto.SHA256,
 			},
-			want:    `MFswCwYJYIZIAWUDBAIBBCCeWLRusNLb--vmWOkxm34qDjTMWkc3utIhOMoMwKDqbgQg2iiKWySZrD-6c88HMZ6vhIHZPamChLlzGHeZ7pTS8jYCCD6jRWhlRB8c`,
+			want:    `aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE`,
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateCertID(tt.args.cert, tt.args.issuer, tt.args.hashFunc)
+			got, err := generateARICertID(tt.args.cert)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("generateCertID() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("generateARICertID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("generateCertID() error\n got  = %v\n want = %v", got, tt.want)
+				t.Errorf("generateARICertID() error\n got  = %v\n want = %v", got, tt.want)
 			}
 		})
 	}

--- a/challenge.go
+++ b/challenge.go
@@ -15,7 +15,7 @@ func EncodeDNS01KeyAuthorization(keyAuth string) string {
 	return base64.RawURLEncoding.EncodeToString(h[:])
 }
 
-// Helper function to determine whether a challenge is "finished" by it's status.
+// Helper function to determine whether a challenge is "finished" by its status.
 func checkUpdatedChallengeStatus(challenge Challenge) (bool, error) {
 	switch challenge.Status {
 	case "pending":

--- a/examples/ari/renewalinfo.go
+++ b/examples/ari/renewalinfo.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -116,14 +115,17 @@ func main() {
 	cert, err := client.FetchCertificates(account, order.Certificate)
 	ifpanic(err)
 
-	ri, err := client.GetRenewalInfo(cert[0], cert[1], crypto.SHA256)
+	ri, err := client.GetRenewalInfo(cert[0])
 	ifpanic(err)
+
+	shouldRenewAt := ri.ShouldRenewAt(time.Now(), time.Duration(1*time.Second))
 
 	fmt.Println("Renewal info:")
 	fmt.Printf(" - Start: %s\n", ri.SuggestedWindow.Start)
 	fmt.Printf(" - End: %s\n", ri.SuggestedWindow.End)
 	fmt.Printf(" - URL: %s\n", ri.ExplanationURL)
 	fmt.Printf(" - Retry-After: %s\n", ri.RetryAfter)
+	fmt.Printf(" - Renew-At: %s\n", shouldRenewAt)
 }
 
 func ifpanic(err error) {

--- a/order.go
+++ b/order.go
@@ -23,10 +23,13 @@ func (c Client) NewOrderDomains(account Account, domains ...string) (Order, erro
 	return c.ReplacementOrder(account, nil, identifiers)
 }
 
-// ReplacementOrder takes an existing *x509.Certificate and initiates a new order for a new certificate, but with the
-// order being marked as a replacement. Replacement orders are exempt from Let's Encrypt NewOrder rate limits.
-// At least one identifier must match the list of identifiers from the parent order to be considered as a valid
-// replacement order.
+// ReplacementOrder takes an existing *x509.Certificate and initiates a new
+// order for a new certificate, but with the order being marked as a
+// replacement. Replacement orders which are valid replacements are (currently)
+// exempt from Let's Encrypt NewOrder rate limits, but may not be exempt from
+// other ACME CAs ACME Renewal Info implementations. At least one identifier
+// must match the list of identifiers from the parent order to be considered as
+// a valid replacement order.
 // See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
 func (c Client) ReplacementOrder(account Account, oldCert *x509.Certificate, identifiers []Identifier) (Order, error) {
 	// If an old cert being replaced is present and the acme directory doesn't list a RenewalInfo endpoint,

--- a/order.go
+++ b/order.go
@@ -52,7 +52,7 @@ func (c Client) NewOrderRenewal(account Account, oldCert *x509.Certificate, doma
 		return nil, fmt.Errorf("certificate not found")
 	}
 
-	certID, err := generateARICertID(oldCert)
+	certID, err := GenerateARICertID(oldCert)
 	if err != nil {
 		return nil, fmt.Errorf("acme: error generating certificate id: %v", err)
 	}

--- a/order.go
+++ b/order.go
@@ -9,124 +9,64 @@ import (
 	"time"
 )
 
-// NewOrder initiates a new order for a new certificate. This method does not
-// use ACME Renewal Info.
-func (c Client) NewOrder(account Account, identifiers []Identifier) (*Order, error) {
-	newOrderResp, err := c.postNewOrder(account, identifiers, nil)
-	if err != nil {
-		return newOrderResp, err
+// NewOrder initiates a new order for a new certificate. This method does not use ACME Renewal Info.
+func (c Client) NewOrder(account Account, identifiers []Identifier) (Order, error) {
+	return c.ReplacementOrder(account, nil, identifiers)
+}
+
+// NewOrderDomains takes a list of domain dns identifiers for a new certificate. Essentially a helper function.
+func (c Client) NewOrderDomains(account Account, domains ...string) (Order, error) {
+	var identifiers []Identifier
+	for _, d := range domains {
+		identifiers = append(identifiers, Identifier{Type: "dns", Value: d})
 	}
-
-	return newOrderResp, nil
+	return c.ReplacementOrder(account, nil, identifiers)
 }
 
-// NewOrderDomains is a wrapper for NewOrder(AcmeAccount, []AcmeIdentifiers). It
-// creates a dns identifier for each provided domain. This method does not use
-// ACME Renewal Info.
-func (c Client) NewOrderDomains(account Account, domains ...string) (*Order, error) {
-	ids, err := domainsToIds(domains)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.NewOrder(account, ids)
-}
-
-type ariRequest struct {
-	certID string
-}
-
-// NewOrderRenewal takes an existing *x509.Certificate and initiates a new order
-// for a new certificate, but with the order being marked as a replacement.
-// Replacement orders are exempt from Let's Encrypt NewOrder rate limits. It
-// creates a dns identifier for each provided domain. At least one identifier
-// must match the list of identifiers from the parent order to be considered as
-// a valid replacment order.
+// ReplacementOrder takes an existing *x509.Certificate and initiates a new order for a new certificate, but with the
+// order being marked as a replacement. Replacement orders are exempt from Let's Encrypt NewOrder rate limits.
+// At least one identifier must match the list of identifiers from the parent order to be considered as a valid
+// replacement order.
 // See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
-func (c Client) NewOrderRenewal(account Account, oldCert *x509.Certificate, domains ...string) (*Order, error) {
-	if c.dir.RenewalInfo == "" {
-		return nil, ErrRenewalInfoNotSupported
+func (c Client) ReplacementOrder(account Account, oldCert *x509.Certificate, identifiers []Identifier) (Order, error) {
+	// If an old cert being replaced is present and the acme directory doesn't list a RenewalInfo endpoint,
+	// throw an error. This endpoint being present indicates support for ARI.
+	if oldCert != nil && c.dir.RenewalInfo == "" {
+		return Order{}, ErrRenewalInfoNotSupported
 	}
 
-	if oldCert == nil {
-		return nil, fmt.Errorf("certificate not found")
+	// 'replaces' is specifically listed as 'omitempty' so the json encoder doesn't include this key
+	// if the ari oldCert is nil
+	newOrderReq := struct {
+		Identifiers []Identifier `json:"identifiers"`
+		Replaces    string       `json:"replaces,omitempty"`
+	}{
+		Identifiers: identifiers,
 	}
 
-	certID, err := GenerateARICertID(oldCert)
-	if err != nil {
-		return nil, fmt.Errorf("acme: error generating certificate id: %v", err)
-	}
-
-	ids, err := domainsToIds(domains)
-	if err != nil {
-		return nil, err
-	}
-
-	ari := &ariRequest{certID: certID}
-	newOrderResp, err := c.postNewOrder(account, ids, ari)
-	if err != nil {
-		return nil, err
-	}
-
-	return newOrderResp, nil
-}
-
-// postNewOrder handles the logic of POSTing either 1) an ACME Renewal Info (ARI)
-// replacement order or 2) a standard RFC 8555 order to the ACME server and returns an
-// error.
-func (c Client) postNewOrder(account Account, ids []Identifier, ari *ariRequest) (*Order, error) {
-	type newOrderRequest interface{}
-	var newOrderReq newOrderRequest
-
-	// This order object will be returned to the client.
-	order := Order{}
-	if ari != nil {
-		order.Replaces = ari.certID
-		ariNewOrderReq := struct {
-			Identifiers []Identifier `json:"identifiers"`
-			Replaces    string
-		}{
-			Identifiers: ids,
-			Replaces:    ari.certID,
+	// If present, add the ari cert ID from the original/old certificate
+	if oldCert != nil {
+		replacesCertID, err := GenerateARICertID(oldCert)
+		if err != nil {
+			return Order{}, fmt.Errorf("acme: error generating replacement certificate id: %v", err)
 		}
-		newOrderReq = ariNewOrderReq
-	} else {
-		nonARINewOrderReq := struct {
-			Identifiers []Identifier `json:"identifiers"`
-		}{
-			Identifiers: ids,
-		}
-		newOrderReq = nonARINewOrderReq
+
+		newOrderReq.Replaces = replacesCertID
 	}
 
 	// Submit the order
-	resp, err := c.post(c.dir.NewOrder, account.URL, account.PrivateKey, newOrderReq, &order, http.StatusCreated)
+	newOrderResp := Order{}
+	resp, err := c.post(c.dir.NewOrder, account.URL, account.PrivateKey, newOrderReq, &newOrderResp, http.StatusCreated)
 	if err != nil {
-		return nil, err
+		return newOrderResp, err
 	}
-	order.URL = resp.Header.Get("Location")
-
-	return &order, nil
-}
-
-// domainsToIds takes a slice of strings representing domain names and returns a
-// slice of Identifiers or an error.
-func domainsToIds(domains []string) ([]Identifier, error) {
-	if len(domains) == 0 {
-		return nil, errors.New("acme: no domains provided")
-	}
-
-	var ids []Identifier
-	for _, d := range domains {
-		ids = append(ids, Identifier{Type: "dns", Value: d})
-	}
-
-	return ids, nil
+	newOrderResp.URL = resp.Header.Get("Location")
+	return newOrderResp, nil
 }
 
 // FetchOrder fetches an existing order given an order url.
-func (c Client) FetchOrder(account Account, orderURL string) (*Order, error) {
-	orderResp := &Order{
+func (c Client) FetchOrder(account Account, orderURL string) (Order, error) {
+	orderResp := Order{
 		URL: orderURL, // boulder response doesn't seem to contain location header for this request
 	}
 	_, err := c.post(orderURL, account.URL, account.PrivateKey, "", &orderResp, http.StatusOK)
@@ -134,12 +74,8 @@ func (c Client) FetchOrder(account Account, orderURL string) (*Order, error) {
 	return orderResp, err
 }
 
-// Helper function to determine whether an order is "finished" by it's status.
-func checkFinalizedOrderStatus(order *Order) (bool, error) {
-	if order == nil {
-		return false, errors.New("acme: nil order")
-	}
-
+// Helper function to determine whether an order is "finished" by its status.
+func checkFinalizedOrderStatus(order Order) (bool, error) {
 	switch order.Status {
 	case "invalid":
 		// "invalid": The certificate will not be issued.  Consider this
@@ -181,7 +117,7 @@ func checkFinalizedOrderStatus(order *Order) (bool, error) {
 // FinalizeOrder indicates to the acme server that the client considers an order complete and "finalizes" it.
 // If the server believes the authorizations have been filled successfully, a certificate should then be available.
 // This function assumes that the order status is "ready".
-func (c Client) FinalizeOrder(account Account, order *Order, csr *x509.CertificateRequest) (*Order, error) {
+func (c Client) FinalizeOrder(account Account, order Order, csr *x509.CertificateRequest) (Order, error) {
 	finaliseReq := struct {
 		Csr string `json:"csr"`
 	}{

--- a/order_test.go
+++ b/order_test.go
@@ -108,6 +108,14 @@ func TestClient_NewOrderDomains(t *testing.T) {
 	}
 }
 
+func TestClient_NewOrderReplacement(t *testing.T) {
+	account := makeAccount(t)
+	_, err := testClient.NewOrderRenewal(account, nil)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
 func Test_checkFinalizedOrderStatus(t *testing.T) {
 	tests := []struct {
 		Order       *Order

--- a/order_test.go
+++ b/order_test.go
@@ -110,50 +110,55 @@ func TestClient_NewOrderDomains(t *testing.T) {
 
 func Test_checkFinalizedOrderStatus(t *testing.T) {
 	tests := []struct {
-		Order       Order
+		Order       *Order
 		Finished    bool
 		HasError    bool
 		ErrorString string
 	}{
 		{
-			Order:       Order{Status: "invalid"},
+			Order:       &Order{Status: "invalid"},
 			Finished:    true,
 			HasError:    true,
 			ErrorString: "no error provided",
 		},
 		{
-			Order:       Order{Status: "invalid", Error: Problem{Type: "blahblahblah"}},
+			Order:       &Order{Status: "invalid", Error: Problem{Type: "blahblahblah"}},
 			Finished:    true,
 			HasError:    true,
 			ErrorString: "blahblahblah",
 		},
 		{
-			Order:       Order{Status: "pending"},
+			Order:       &Order{Status: "pending"},
 			Finished:    true,
 			HasError:    true,
 			ErrorString: "not fulfilled",
 		},
 		{
-			Order:       Order{Status: "ready"},
+			Order:       &Order{Status: "ready"},
 			Finished:    true,
 			HasError:    true,
 			ErrorString: "unexpected",
 		},
 		{
-			Order:    Order{Status: "processing"},
+			Order:    &Order{Status: "processing"},
 			Finished: false,
 			HasError: false,
 		},
 		{
-			Order:    Order{Status: "valid"},
+			Order:    &Order{Status: "valid"},
 			Finished: true,
 			HasError: false,
 		},
 		{
-			Order:       Order{Status: "asdfasdf"},
+			Order:       &Order{Status: "asdfasdf"},
 			Finished:    true,
 			HasError:    true,
 			ErrorString: "unknown order status",
+		},
+		{
+			Order:       nil,
+			HasError:    true,
+			ErrorString: "nil order",
 		},
 	}
 

--- a/order_test.go
+++ b/order_test.go
@@ -6,6 +6,51 @@ import (
 	"testing"
 )
 
+func TestDomainsToIds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                string
+		domains             []string
+		expectedIdentifiers []Identifier
+		expectedFailure     bool
+	}{
+		{
+			name:            "No domains",
+			domains:         nil,
+			expectedFailure: true,
+		},
+		{
+			name:                "One domain",
+			domains:             []string{"example.com"},
+			expectedIdentifiers: []Identifier{{"dns", "example.com"}},
+		},
+		{
+			name:                "Multiple domains",
+			domains:             []string{"example.org", "example.net"},
+			expectedIdentifiers: []Identifier{{"dns", "example.org"}, {"dns", "example.net"}},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ids, err := domainsToIds(tc.domains)
+			if !tc.expectedFailure {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if len(ids) != len(tc.expectedIdentifiers) {
+				t.Fatalf("unexpected amount of IDs: %d != %d", len(ids), len(tc.expectedIdentifiers))
+			}
+			if !reflect.DeepEqual(ids, tc.expectedIdentifiers) {
+				t.Fatalf("unexpected error: %v != %v", ids, tc.expectedIdentifiers)
+			}
+		})
+	}
+}
+
 func TestClient_NewOrder(t *testing.T) {
 	key := makePrivateKey(t)
 	account, err := testClient.NewAccount(key, false, true)

--- a/types.go
+++ b/types.go
@@ -43,12 +43,14 @@ const (
 // Directory object as returned from the client's directory url upon creation of client.
 // See https://tools.ietf.org/html/rfc8555#section-7.1.1
 type Directory struct {
-	NewNonce    string `json:"newNonce"`    // url to new nonce endpoint
-	NewAccount  string `json:"newAccount"`  // url to new account endpoint
-	NewOrder    string `json:"newOrder"`    // url to new order endpoint
-	NewAuthz    string `json:"newAuthz"`    // url to new authz endpoint
-	RevokeCert  string `json:"revokeCert"`  // url to revoke cert endpoint
-	KeyChange   string `json:"keyChange"`   // url to key change endpoint
+	NewNonce   string `json:"newNonce"`   // url to new nonce endpoint
+	NewAccount string `json:"newAccount"` // url to new account endpoint
+	NewOrder   string `json:"newOrder"`   // url to new order endpoint
+	NewAuthz   string `json:"newAuthz"`   // url to new authz endpoint
+	RevokeCert string `json:"revokeCert"` // url to revoke cert endpoint
+	KeyChange  string `json:"keyChange"`  // url to key change endpoint
+
+	// https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03
 	RenewalInfo string `json:"renewalInfo"` // url to renewal info endpoint
 
 	// meta object containing directory metadata
@@ -154,6 +156,11 @@ type Order struct {
 
 	// RetryAfter is the http Retry-After header from the order response
 	RetryAfter time.Time `json:"-"`
+
+	// Replaces (optional, string): A string uniquely identifying a
+	// previously-issued certificate which this order is intended to replace.
+	// See https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03#section-5
+	Replaces string `json:"replaces,omitempty"`
 }
 
 // Authorization object returned when fetching an authorization in an order.

--- a/types.go
+++ b/types.go
@@ -15,7 +15,7 @@ var (
 	// ErrRenewalInfoNotSupported is returned by Client.GetRenewalInfo if the
 	// renewal info entry isn't present on the acme directory (ie, it's not
 	// supported by the acme server)
-	ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not")
+	ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not supported")
 )
 
 // Different possible challenge types provided by an ACME server.

--- a/types.go
+++ b/types.go
@@ -228,7 +228,7 @@ type RenewalInfo struct {
 		Start time.Time `json:"start"`
 		End   time.Time `json:"end"`
 	} `json:"suggestedWindow"`
-	ExplanationURL string `json:"explanationURL"`
+	ExplanationURL string `json:"explanationURL,omitempty"`
 
 	RetryAfter time.Time `json:"-"`
 }

--- a/types.go
+++ b/types.go
@@ -8,8 +8,15 @@ import (
 	"time"
 )
 
-// ErrUnsupportedKey is returned when an unsupported key type is encountered.
-var ErrUnsupportedKey = errors.New("acme: unknown key type; only RSA and ECDSA are supported")
+var (
+	// ErrUnsupportedKey is returned when an unsupported key type is encountered.
+	ErrUnsupportedKey = errors.New("acme: unknown key type; only RSA and ECDSA are supported")
+
+	// ErrRenewalInfoNotSupported is returned by Client.GetRenewalInfo if the
+	// renewal info entry isn't present on the acme directory (ie, it's not
+	// supported by the acme server)
+	ErrRenewalInfoNotSupported = errors.New("renewal information endpoint not")
+)
 
 // Different possible challenge types provided by an ACME server.
 // See https://tools.ietf.org/html/rfc8555#section-9.7.8
@@ -122,7 +129,7 @@ type Account struct {
 //   - "HS384" for HashFunc: crypto.SHA384
 //   - "HS512" for HashFunc: crypto.SHA512
 //
-// However this is dependant on the acme server in question and is provided here to give more options for future compatibility.
+// However this is dependent on the acme server in question and is provided here to give more options for future compatibility.
 type ExternalAccountBinding struct {
 	KeyIdentifier string      `json:"-"`
 	MacKey        string      `json:"-"`
@@ -212,4 +219,16 @@ type NewAccountRequest struct {
 	TermsOfServiceAgreed   bool            `json:"termsOfServiceAgreed"`
 	Contact                []string        `json:"contact,omitempty"`
 	ExternalAccountBinding json.RawMessage `json:"externalAccountBinding"`
+}
+
+// RenewalInfo stores the server-provided suggestions on when to renew
+// certificates.
+type RenewalInfo struct {
+	SuggestedWindow struct {
+		Start time.Time `json:"start"`
+		End   time.Time `json:"end"`
+	} `json:"suggestedWindow"`
+	ExplanationURL string `json:"explanationURL"`
+
+	RetryAfter time.Time `json:"-"`
 }

--- a/utility_test.go
+++ b/utility_test.go
@@ -123,7 +123,7 @@ func makeAccount(t *testing.T) Account {
 	return account
 }
 
-func makeOrder(t *testing.T, identifiers ...Identifier) (Account, *Order) {
+func makeOrder(t *testing.T, identifiers ...Identifier) (Account, Order) {
 	if len(identifiers) == 0 {
 		identifiers = []Identifier{{Type: "dns", Value: randString() + ".com"}}
 	}
@@ -144,7 +144,7 @@ func makeOrder(t *testing.T, identifiers ...Identifier) (Account, *Order) {
 	return account, order
 }
 
-func makeOrderFinalised(t *testing.T, supportedChalTypes []string, identifiers ...Identifier) (Account, *Order, crypto.Signer) {
+func makeOrderFinalised(t *testing.T, supportedChalTypes []string, identifiers ...Identifier) (Account, Order, crypto.Signer) {
 	if len(supportedChalTypes) == 0 {
 		supportedChalTypes = []string{ChallengeTypeDNS01, ChallengeTypeHTTP01}
 	}

--- a/utility_test.go
+++ b/utility_test.go
@@ -123,7 +123,7 @@ func makeAccount(t *testing.T) Account {
 	return account
 }
 
-func makeOrder(t *testing.T, identifiers ...Identifier) (Account, Order) {
+func makeOrder(t *testing.T, identifiers ...Identifier) (Account, *Order) {
 	if len(identifiers) == 0 {
 		identifiers = []Identifier{{Type: "dns", Value: randString() + ".com"}}
 	}
@@ -144,7 +144,7 @@ func makeOrder(t *testing.T, identifiers ...Identifier) (Account, Order) {
 	return account, order
 }
 
-func makeOrderFinalised(t *testing.T, supportedChalTypes []string, identifiers ...Identifier) (Account, Order, crypto.Signer) {
+func makeOrderFinalised(t *testing.T, supportedChalTypes []string, identifiers ...Identifier) (Account, *Order, crypto.Signer) {
 	if len(supportedChalTypes) == 0 {
 		supportedChalTypes = []string{ChallengeTypeDNS01, ChallengeTypeHTTP01}
 	}


### PR DESCRIPTION
I've updated all draft-ietf-acme-ari-01 code with the latest version, [draft-ietf-acme-ari-03](https://datatracker.ietf.org/doc/html/draft-ietf-acme-ari-03). Big thanks to @beautifulentropy for [this blog post](https://letsencrypt.org/2024/04/25/guide-to-integrating-ari-into-existing-acme-clients) which made the work very easy. Client authors can specify an optional `*x509.Certificate` for ARI certificate replacements attempts via `client.ReplacementOrder`. The existing `client.NewOrder` and `client.NewOrderDomains` become a thin wrapper around `client.ReplacementOrder` that will not trigger a certificate replacement.
