### PR TITLE
Don't assume Finalize responses come with a Location header

### DIFF
--- a/order.go
+++ b/order.go
@@ -159,8 +159,6 @@ func (c Client) FinalizeOrder(account Account, order Order, csr *x509.Certificat
 		return order, err
 	}
 
-	order.URL = resp.Header.Get("Location")
-
 	updateOrder := func(resp *http.Response) (bool, error) {
 		if finished, err := checkFinalizedOrderStatus(order); finished {
 			return true, err


### PR DESCRIPTION
Although RFC 8555 includes a Location header in the *example* response for a Finalize request, nowhere does the text say that including such a header is required. Additionally, the Location header technically only applies to HTTP 3XX and 201 status codes, while a Finalize response is usually accompanied by a 200 OK or a 202 Accepted (for async finalize). It turns out that there are existing ACME implementations which do not include this header, so we shouldn't assume it will be present.

See https://github.com/letsencrypt/pebble/issues/508 for more context.